### PR TITLE
Bump `stremio-official-addons`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1013,9 +1013,9 @@
             }
         },
         "stremio-official-addons": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/stremio-official-addons/-/stremio-official-addons-1.4.0.tgz",
-            "integrity": "sha512-8JGD3ACT1V/eChHAXLya6h07m6xQ8G3MuNmc1rmzhptQGJWo2/wrF7QNnkjLtvFLyxjEwwekzg7nb8F6MuNy6g=="
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/stremio-official-addons/-/stremio-official-addons-1.5.0.tgz",
+            "integrity": "sha512-Kcr8M7qvOPdR56ZNw4GxCTMrWQte1KfedAixKt6mHkimxDfEPgrsmdHra1sLb3JDSf2zRXP1sF1GbuEXlWeLLA=="
         },
         "string-width": {
             "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "events": "1.1.0",
         "node-fetch": "2.2.0",
         "stremio-addon-client": "^1.14.5",
-        "stremio-official-addons": "^1.4.0"
+        "stremio-official-addons": "^1.5.0"
     },
     "devDependencies": {
         "eslint": "^5.14.1",


### PR DESCRIPTION
Bumps `stremio-official-addons`, required to not use 2 versions of `stremio-official-addons` in the `stremio` repo as it will be bumped there too.

